### PR TITLE
End address of Z1013 header must point to last the address  of binary

### DIFF
--- a/src/appmake/z1013.c
+++ b/src/appmake/z1013.c
@@ -99,7 +99,7 @@ int z1013_exec(char* target)
     }
 
     writeword(pos, fpout);
-    writeword(pos + len, fpout);
+    writeword(pos + len - 1, fpout);
     writeword(pos, fpout);
 
     /* 6 bytes set to zero */


### PR DESCRIPTION
The end address of the so called Z1013 'Headersave' header must point to the last byte of the binary instead of one Byte behind.